### PR TITLE
Fix/utf8 space

### DIFF
--- a/mxpyserializer/basic_type.py
+++ b/mxpyserializer/basic_type.py
@@ -3,6 +3,7 @@ author: Etienne Wallet
 
 This module contains the functions to serialize and deserialize basic types
 """
+
 import re
 from typing import Tuple, Union
 
@@ -30,6 +31,7 @@ BASIC_TYPES = (
     "TokenIdentifier",
     "EgldOrEsdtTokenIdentifier",
     "utf-8 string",
+    "utf-8string",
 )
 
 
@@ -165,7 +167,12 @@ def nested_decode_basic(
         hex_address, data = data[:32].hex(), data[32:]
         return Address.from_hex(hex_address, "erd").bech32(), data
 
-    if type_name in ("TokenIdentifier", "EgldOrEsdtTokenIdentifier", "utf-8 string"):
+    if type_name in (
+        "TokenIdentifier",
+        "EgldOrEsdtTokenIdentifier",
+        "utf-8 string",
+        "utf-8string",
+    ):
         element, data = get_bytes_element_from_size(data)
         return element.decode("utf-8"), data
 
@@ -203,7 +210,12 @@ def top_decode_basic(type_name: str, data: bytes) -> Union[int, str, bool, Addre
     if type_name == "Address":
         return Address.from_hex(data.hex(), "erd").bech32()
 
-    if type_name in ("TokenIdentifier", "EgldOrEsdtTokenIdentifier", "utf-8 string"):
+    if type_name in (
+        "TokenIdentifier",
+        "EgldOrEsdtTokenIdentifier",
+        "utf-8 string",
+        "utf-8string",
+    ):
         return data.decode("utf-8")
 
     raise errors.UnknownType(type_name)
@@ -261,7 +273,12 @@ def nested_encode_basic(
             f"Address type expected an Adress or a bech32 string but got {value}"
         )
 
-    if type_name in ("TokenIdentifier", "EgldOrEsdtTokenIdentifier", "utf-8 string"):
+    if type_name in (
+        "TokenIdentifier",
+        "EgldOrEsdtTokenIdentifier",
+        "utf-8 string",
+        "utf-8string",
+    ):
         encoded_value = str(value).encode("utf-8")
         encoded_size = nested_encode_basic("u32", len(encoded_value))
         return encoded_size + encoded_value
@@ -311,7 +328,12 @@ def top_encode_basic(type_name: str, value: Union[int, str, bool, Address]) -> b
             f"Address type expected an Adress or a bech32 strin but got {value}"
         )
 
-    if type_name in ("TokenIdentifier", "EgldOrEsdtTokenIdentifier", "utf-8 string"):
+    if type_name in (
+        "TokenIdentifier",
+        "EgldOrEsdtTokenIdentifier",
+        "utf-8 string",
+        "utf-8string",
+    ):
         return str(value).encode("utf-8")
 
     raise errors.UnknownType(type_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mxpyserializer"
-version = "0.3.0"
+version = "0.3.1-dev0"
 authors = [
   {name="Etienne Wallet"},
 ]

--- a/tests/test_decode_basic.py
+++ b/tests/test_decode_basic.py
@@ -67,6 +67,11 @@ def test_nested_decode_integer_data_too_small():
             ("heythisisastring", b"\x01\x0a\xaa\xaa"),
         ),
         (
+            "utf-8string",
+            b"\x00\x00\x00\x10heythisisastring\x01\x0a\xaa\xaa",
+            ("heythisisastring", b"\x01\x0a\xaa\xaa"),
+        ),
+        (
             "TokenIdentifier",
             b"\x00\x00\x00\x0ATKN-abcdef\x01\x0a\xaa\xaa",
             ("TKN-abcdef", b"\x01\x0a\xaa\xaa"),
@@ -181,6 +186,7 @@ def test_wrong_bool_nested_decode():
         ("bool", b"\x01", True),
         ("bool", b"", False),
         ("utf-8 string", b"heythisisastring", "heythisisastring"),
+        ("utf-8string", b"heythisisastring", "heythisisastring"),
         (
             "TokenIdentifier",
             b"TKN-abcdef",

--- a/tests/test_encode_basic.py
+++ b/tests/test_encode_basic.py
@@ -54,6 +54,11 @@ def test_nested_encode_integer(
             b"\x00\x00\x00\x10heythisisastring",
         ),
         (
+            "utf-8string",
+            "heythisisastring",
+            b"\x00\x00\x00\x10heythisisastring",
+        ),
+        (
             "TokenIdentifier",
             "TKN-abcdef",
             b"\x00\x00\x00\x0ATKN-abcdef",
@@ -106,6 +111,7 @@ def test_nested_encode_basic(type_name: str, value: Any, expected_result: bytes)
         ("bool", True, b"\x01"),
         ("bool", False, b""),
         ("utf-8 string", "heythisisastring", b"heythisisastring"),
+        ("utf-8string", "heythisisastring", b"heythisisastring"),
         (
             "TokenIdentifier",
             "TKN-abcdef",


### PR DESCRIPTION
Fixed:
- handle case when the space for the type 'utf-8 string' is missing